### PR TITLE
feat(deploy): cleanup comment, add ethernet internface debug tutorial…

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,16 +263,23 @@ source ~/.bashrc
 ```
 
 ### Running on the Real Robot
-- Replace `"<your-unitree-sdk2-path>"` in `./rl_policy/bfm_zero.py`
-- Use the real-robot config: `config/robot/g1_real.yaml`. 
+- In [`./rl_policy/bfm_zero.py`](./rl_policy/bfm_zero.py), replace `"/path/to/your/unitree_sdk2/build/lib"` with the actual path to your Unitree SDK2 installation (e.g., `sys.path.append("/home/unitree/User/unitree_sdk2/build/lib")`).
 
-  (i.e. `python rl_policy/bfm_zero.py \
+- When deploying to the real robot, use the real-robot configuration file [`g1_real.yaml`](config/robot/g1_real.yaml) instead of the simulation configuration [`g1.yaml`](config/robot/g1.yaml).
+
+
+  ```python
+  python rl_policy/bfm_zero.py \
     --robot_config config/robot/g1_real.yaml \
     --policy_config ${POLICY_CONFIG} \
     --model_path ${MODEL_ONNX_PATH} \
-    --task  ${TASK}`)
-
+    --task  ${TASK}
+  ```
 ---
+
+### Known Issues
+- If you encounter an error stating that `eth0` is not a valid network interface, update the interface name in the file ['./config/robot/g1_real.yaml'](config/robot/g1_real.yaml) to match your robot’s actual network interface (e.g., `eth1`).
+
 
 
 ## 👥 Citation

--- a/config/robot/g1_real.yaml
+++ b/config/robot/g1_real.yaml
@@ -1,15 +1,9 @@
 ROBOT_TYPE: 'g1_real' # Robot name, "go2", "b2", "b2w", "h1", "go2w", "g1" 
- ### REAL
-# # DOMAIN_ID: 0 # Domain id
-# # # Interface
-# # INTERFACE: "en0" # Yuanhang: in simulation, lo0 for mac, lo for linux
-
+### REAL
 ## SIM
 DOMAIN_ID: 0 # Domain id
 # Interface
-# INTERFACE: "eth0" # Yuanhang: in simulation, lo0 for mac, lo for linux
-INTERFACE: "eth0" # "eth1" # Tonghe & Jimmyh for G1 5840
-# INTERFACE: "eth1" # Tonghe & Jimmyh for G1 5848
+INTERFACE: "eth0"   # "eth1"   
 USE_JOYSTICK: True
 
 

--- a/rl_policy/bfm_zero.py
+++ b/rl_policy/bfm_zero.py
@@ -38,7 +38,7 @@ class BFMZeroPolicy:
         robot_type = robot_config["ROBOT_TYPE"]
         if robot_type == "g1_real":
             # example: sys.path.append("/home/unitree/User/unitree_sdk2/build/lib")
-            sys.path.append("<your-unitree-sdk2-path>")
+            sys.path.append("/path/to/your/unitree_sdk2/build/lib")
             import g1_interface
             network_interface = robot_config.get("INTERFACE", None)
             self.robot = g1_interface.G1Interface(network_interface)


### PR DESCRIPTION
### Description
Add comments in deployment code readme on how to debug ethernet interface error.  
Streamline deployment code readme and the real robot configuration file. 

### Motivation and Context
Provide a clearer description for the deployment code
Offer an instant solution to common ethernet interface error. 

### How has this been tested?
We use the provided method to debug ethernet interface errors in two Unitree G1 robots with and successfully resolved the error. 

### Additional information (optional, e.g., figures and logs):
### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)